### PR TITLE
Add injection script and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,25 @@ The goal is to provide instructional designers with a lightweight way to add an 
 
 ## Usage
 
-1. Publish your Rise360 course (web or LMS package).
-2. Insert the code from [`embed.html`](embed.html) into the course's `index.html` (or a common layout file) just before the closing `</body>` tag.
-3. Replace the `agentId` value with your own Letta agent ID.
-4. Upload the modified course to your LMS or web host.
+1. Export your course from Rise360 as a **Web** or **LMS** package and download the ZIP archive.
+2. Extract the archive to a local folder on your computer.
+3. Open the course's `index.html` file in a text editor.
+4. Copy the markup from [`embed.html`](embed.html) and paste it immediately **before** the closing `</body>` tag in `index.html` (or any common layout file used by your course).
+5. Replace the `agentId` value in the snippet with the ID of your own Letta agent.
+6. Save the file and re‑zip the course if required by your LMS.
+7. Upload the updated package to your LMS or web host.
 
 When learners view the course, the Letta bubble will appear in the corner of the screen. Clicking it opens a chat window connected to your configured Letta agent.
+
+### Optional: automate the injection
+
+You can use the helper script in the `scripts/` directory to insert the snippet automatically:
+
+```bash
+python scripts/inject_snippet.py path/to/index.html
+```
+
+Pass a second argument to specify a custom snippet file. After running the script, deploy the course as usual.
 
 ## Project Plan
 

--- a/scripts/inject_snippet.py
+++ b/scripts/inject_snippet.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+SNIPPET_FILE = Path(__file__).resolve().parent.parent / "embed.html"
+
+USAGE = """Usage: python inject_snippet.py <path/to/index.html> [snippet.html]\n"""
+
+def load_snippet(path: Path) -> str:
+    try:
+        return path.read_text()
+    except Exception as e:
+        raise SystemExit(f"Failed to read snippet {path}: {e}")
+
+def inject(target: Path, snippet: str) -> None:
+    try:
+        text = target.read_text()
+    except Exception as e:
+        raise SystemExit(f"Failed to read {target}: {e}")
+
+    if snippet.strip() in text:
+        print("Snippet already present")
+        return
+
+    close_tag = "</body>"
+    idx = text.lower().rfind(close_tag)
+    if idx == -1:
+        raise SystemExit(f"No closing </body> tag found in {target}")
+
+    new_text = text[:idx] + snippet + "\n" + text[idx:]
+    target.write_text(new_text)
+    print(f"Injected snippet into {target}")
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print(USAGE)
+        return
+
+    html_path = Path(argv[0])
+    snippet_path = Path(argv[1]) if len(argv) > 1 else SNIPPET_FILE
+    snippet = load_snippet(snippet_path)
+    inject(html_path, snippet)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand the README usage instructions with step-by-step HTML edit guidance
- document an optional automation step for injecting the snippet
- add `scripts/inject_snippet.py` helper for inserting the embed markup

## Testing
- `python3 -m py_compile scripts/inject_snippet.py`